### PR TITLE
feat: Initial UI pages for repair and recycle

### DIFF
--- a/seweco/ios/Flutter/Debug.xcconfig
+++ b/seweco/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/seweco/ios/Flutter/Release.xcconfig
+++ b/seweco/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/seweco/ios/Podfile
+++ b/seweco/ios/Podfile
@@ -1,0 +1,41 @@
+# Uncomment this line to define a global platform for your project
+# platform :ios, '9.0'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure flutter pub get is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Generated.xcconfig, then run flutter pub get"
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_ios_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_ios_build_settings(target)
+  end
+end

--- a/seweco/lib/Repair/repair.dart
+++ b/seweco/lib/Repair/repair.dart
@@ -1,6 +1,33 @@
+// import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
+// import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+//  AIzaSyDOKsGoATFKR4VszW6bxwU054UHhVtgHU4
 
 class RepairOptionsScreen extends StatelessWidget {
+  final List<String> articles = <String>[
+    'https://www.google.com/search?q=how+to+repair+clothing',
+    'https://lifehacker.com/how-to-repair-clothes-1843419199',
+    'https://remake.world/stories/style/how-to-mend-your-clothes-during-quarantine-5-easy-stitch-fixes/',
+    'https://www.loveyourclothes.org.uk/care-repair',
+    'https://www.wikihow.com/Fix-Clothes'
+  ];
+
+  // Completer<GoogleMapController> _controller = Completer();
+
+  // static final CameraPosition _kGooglePlex = CameraPosition(
+  //   target: LatLng(37.42796133580664, -122.085749655962),
+  //   zoom: 14.4746,
+  // );
+
+  // static final CameraPosition _kLake = CameraPosition(
+  //     bearing: 192.8334901395799,
+  //     target: LatLng(37.43296265331129, -122.08832357078792),
+  //     tilt: 59.440717697143555,
+  //     zoom: 19.151926040649414);
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -8,21 +35,88 @@ class RepairOptionsScreen extends StatelessWidget {
         title: Text('SewEco!'),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-          ElevatedButton(
+          child: Column(mainAxisAlignment: MainAxisAlignment.center, children: <
+              Widget>[
+        Padding(
+            padding: EdgeInsets.all(24.0),
+            child: Text(
+              'I want to repair an item',
+              textAlign: TextAlign.center,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            )),
+        ElevatedButton(
             child: Text('I want to repair this myself'),
-            onPressed: null
-          ),
-          const SizedBox(height: 30),
-          ElevatedButton(
-            child: Text('I want someone to repair it for me'),
-            onPressed: null
-          ),
-          ]
-        )
-      ),
+            onPressed: () {
+              showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return SimpleDialog(
+                      title: const Text('Useful Articles'),
+                      children: <Widget>[
+                        Container(
+                          height: 300.0,
+                          width: 300.0,
+                          child: ListView.builder(
+                            shrinkWrap: true,
+                            itemCount: articles.length,
+                            itemBuilder: (BuildContext context, int index) {
+                              return Padding(
+                                  padding: EdgeInsets.all(16.0),
+                                  child: Linkify(
+                                    onOpen: (link) async {
+                                      if (await canLaunch(link.url)) {
+                                        await launch(link.url);
+                                      } else {
+                                        throw 'Could not launch $link';
+                                      }
+                                    },
+                                    text: "${articles[index]}",
+                                    style: TextStyle(color: Colors.black),
+                                    linkStyle: TextStyle(color: Colors.blue),
+                                  ));
+                            },
+                          ),
+                        )
+                      ],
+                    );
+                  });
+            }),
+        const SizedBox(height: 30),
+        ElevatedButton(
+            child: Text('I want to find someone who can repair this for me'),
+            onPressed: () {
+              showDialog(
+                  context: context,
+                  builder: (BuildContext context) {
+                    return SimpleDialog(
+                      title: Linkify(
+                        onOpen: (link) async {
+                          if (await canLaunch(link.url)) {
+                            await launch(link.url);
+                          } else {
+                            throw 'Could not launch $link';
+                          }
+                        },
+                        text:
+                            "https://www.google.com/maps/search/clothing+repair/@50.8675778,-1.5116562,10.63z",
+                        style: TextStyle(color: Colors.black),
+                        linkStyle: TextStyle(color: Colors.blue),
+                      ),
+                      children: <Widget>[
+                        // Would be ideal to add a Google Maps widget but need to configure an API key to use
+                        // GoogleMap(
+                        //   mapType: MapType.hybrid,
+                        //   initialCameraPosition: _kGooglePlex,
+                        //   onMapCreated: (GoogleMapController controller) {
+                        //     _controller.complete(controller);
+                        //   },
+                        // ),
+                      ],
+                    );
+                  });
+            }),
+      ])),
     );
   }
 }

--- a/seweco/lib/main.dart
+++ b/seweco/lib/main.dart
@@ -93,21 +93,21 @@ class _MyHomePageState extends State<MyHomePage> {
               onPressed: () {
                 Navigator.pushNamed(context, '/repair');
               }, 
-              child: const Text('I want to repair something')
+              child: const Text('I want to repair an item')
             ),
             const SizedBox(height: 30),
             ElevatedButton(
               onPressed: () {
                 Navigator.pushNamed(context, '/resell');
               }, 
-              child: const Text('I want to resell something')
+              child: const Text('I want to resell an item')
             ),
             const SizedBox(height: 30),
             ElevatedButton(
               onPressed: () {
                 Navigator.pushNamed(context, '/recycle');
               }, 
-              child: const Text('I want to recycle or donate something')
+              child: const Text('I want to recycle or donate an item')
             )
           ],
         ),

--- a/seweco/lib/recycle/recycle.dart
+++ b/seweco/lib/recycle/recycle.dart
@@ -1,6 +1,14 @@
 import 'package:flutter/material.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter_linkify/flutter_linkify.dart';
 
 class RecycleScreen extends StatelessWidget {
+  final List<String> articles = <String>[
+    'https://www.salvationarmy.org.uk/clothing-bank',
+    'https://www.recyclenow.com/what-to-do-with/clothing-textiles-0',
+    'https://www.recyclingsolutions.org.uk/clothing-banks/'
+  ];
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -8,21 +16,53 @@ class RecycleScreen extends StatelessWidget {
         title: Text('SewEco!'),
       ),
       body: Center(
-        child: Column(
-          mainAxisAlignment: MainAxisAlignment.center,
-          children: <Widget>[
-          ElevatedButton(
-            child: Text('Recycle'),
-            onPressed: null
-          ),
-          const SizedBox(height: 30),
-          ElevatedButton(
-            child: Text('Donate'),
-            onPressed: null
-          ),
-          ]
-        )
-      ),
+          child: Column(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: <Widget>[
+            Padding(
+                padding: EdgeInsets.all(24.0),
+                child: Text(
+                  'I want to recycle an item',
+                  textAlign: TextAlign.center,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                )),
+            Padding(
+                padding: EdgeInsets.all(24.0),
+                child: Text(
+                  'Links to local charities/clothes banks accepting donations in your area:',
+                  textAlign: TextAlign.center,
+                  overflow: TextOverflow.ellipsis,
+                  style: const TextStyle(fontWeight: FontWeight.bold),
+                )),
+            // Would be ideal to add a Google Maps widget instead of a list but need to configure an API key to use
+            // Could query websites to find the locations of recyling centres and put pins on a map (using the user's location from the phone)
+            Container(
+              height: 300.0,
+              width: 600.0,
+              child: ListView.builder(
+                shrinkWrap: true,
+                itemCount: articles.length,
+                itemBuilder: (BuildContext context, int index) {
+                  return Padding(
+                      padding: EdgeInsets.all(16.0),
+                      child: Linkify(
+                        onOpen: (link) async {
+                          if (await canLaunch(link.url)) {
+                            await launch(link.url);
+                          } else {
+                            throw 'Could not launch $link';
+                          }
+                        },
+                        text: "${articles[index]}",
+                        textAlign: TextAlign.center,
+                        style: TextStyle(color: Colors.black),
+                        linkStyle: TextStyle(color: Colors.blue),
+                      ));
+                },
+              ),
+            )
+          ])),
     );
   }
 }

--- a/seweco/lib/resell/resell.dart
+++ b/seweco/lib/resell/resell.dart
@@ -1,5 +1,140 @@
 import 'package:flutter/material.dart';
 
+// Define a custom Form widget.
+class ClothingForm extends StatefulWidget {
+  @override
+  ClothingFormState createState() {
+    return ClothingFormState();
+  }
+}
+
+// Define a corresponding State class.
+// This class holds data related to the form.
+class ClothingFormState extends State<ClothingForm> {
+  String colourResult = '';
+  String sizeResult = '';
+  String materialResult = '';
+
+  // Create a global key that uniquely identifies the Form widget
+  // and allows validation of the form.
+  //
+  // Note: This is a `GlobalKey<FormState>`,
+  // not a GlobalKey<MyCustomFormState>.
+  final _formKey = GlobalKey<FormState>();
+
+  @override
+  Widget build(BuildContext context) {
+    // Build a Form widget using the _formKey created above.
+    return Form(
+      key: _formKey,
+      child: Column(
+        children: <Widget>[
+          // Add TextFormFields and ElevatedButton here.
+          Container(
+            width: 400,
+            child: TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'Size *',
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter some text';
+                }
+                sizeResult = value;
+                return null;
+              },
+            )
+          ),
+          const SizedBox(height: 30),
+          Container(
+            width: 400,
+            child: TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'Colour *',
+              ),
+            // The validator receives the text that the user has entered.
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter some text';
+                }
+                colourResult = value;
+                return null;
+              },
+            ),
+          ),
+          const SizedBox(height: 30),
+          Container(
+            width: 400,
+            
+            child: TextFormField(
+              decoration: const InputDecoration(
+                labelText: 'Material *',
+              ),
+              validator: (value) {
+                if (value == null || value.isEmpty) {
+                  return 'Please enter some text';
+                }
+                materialResult = value;
+                return null;
+              },
+            ),
+          ),
+          const SizedBox(height: 30),
+          ElevatedButton(
+            onPressed: () {
+              if (_formKey.currentState!.validate()) {
+                showDialog(
+                  context: context,
+                  builder: (context) {
+                    return Dialog(
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(40)),
+                      elevation: 16,
+                      child: Container(
+                      height: 200.0,
+                      width: 300.0,                        
+                      child: ListView(
+                          children: <Widget>[
+                            SizedBox(height: 20),
+                            Center(
+                              child: Text(
+                                "Size: $sizeResult"
+                              )
+                            ),
+                            const SizedBox(height: 30),
+                            Center(
+                              child: Text(
+                                "Colour: $colourResult"
+                              )
+                            ),
+                            const SizedBox(height: 30),
+                            Center(
+                              child: Text(
+                                "Material: $materialResult"
+                              )
+                            )
+                          ]
+                        )
+                      )
+                    );
+                  }
+                );
+              }
+            }, 
+
+                // you'd often call a server or save the information in a database.
+                
+                  // }
+            //     );
+            // },
+            child: Text('Submit'),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+
 class ResellScreen extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
@@ -11,11 +146,7 @@ class ResellScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-          ElevatedButton(
-            child: Text('TO DO'),
-            onPressed: null
-          ),
-
+          ClothingForm()
           ]
         )
       ),

--- a/seweco/macos/Flutter/Flutter-Debug.xcconfig
+++ b/seweco/macos/Flutter/Flutter-Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/seweco/macos/Flutter/Flutter-Release.xcconfig
+++ b/seweco/macos/Flutter/Flutter-Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "ephemeral/Flutter-Generated.xcconfig"

--- a/seweco/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/seweco/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -5,6 +5,8 @@
 import FlutterMacOS
 import Foundation
 
+import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
+  UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/seweco/macos/Podfile
+++ b/seweco/macos/Podfile
@@ -1,0 +1,40 @@
+platform :osx, '10.11'
+
+# CocoaPods analytics sends network stats synchronously affecting flutter build latency.
+ENV['COCOAPODS_DISABLE_STATS'] = 'true'
+
+project 'Runner', {
+  'Debug' => :debug,
+  'Profile' => :release,
+  'Release' => :release,
+}
+
+def flutter_root
+  generated_xcode_build_settings_path = File.expand_path(File.join('..', 'Flutter', 'ephemeral', 'Flutter-Generated.xcconfig'), __FILE__)
+  unless File.exist?(generated_xcode_build_settings_path)
+    raise "#{generated_xcode_build_settings_path} must exist. If you're running pod install manually, make sure \"flutter pub get\" is executed first"
+  end
+
+  File.foreach(generated_xcode_build_settings_path) do |line|
+    matches = line.match(/FLUTTER_ROOT\=(.*)/)
+    return matches[1].strip if matches
+  end
+  raise "FLUTTER_ROOT not found in #{generated_xcode_build_settings_path}. Try deleting Flutter-Generated.xcconfig, then run \"flutter pub get\""
+end
+
+require File.expand_path(File.join('packages', 'flutter_tools', 'bin', 'podhelper'), flutter_root)
+
+flutter_macos_podfile_setup
+
+target 'Runner' do
+  use_frameworks!
+  use_modular_headers!
+
+  flutter_install_all_macos_pods File.dirname(File.realpath(__FILE__))
+end
+
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    flutter_additional_macos_build_settings(target)
+  end
+end

--- a/seweco/pubspec.lock
+++ b/seweco/pubspec.lock
@@ -43,6 +43,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.15.0"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.2"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -62,11 +69,86 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_linkify:
+    dependency: "direct main"
+    description:
+      name: flutter_linkify
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.2"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.11"
   flutter_test:
     dependency: "direct dev"
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.4.5"
+  google_maps_flutter:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.33"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
+  google_maps_flutter_web:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.0+4"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
+  js_wrapping:
+    dependency: transitive
+    description:
+      name: js_wrapping
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.5.0"
+  linkify:
+    dependency: transitive
+    description:
+      name: linkify
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.0"
   matcher:
     dependency: transitive
     description:
@@ -88,6 +170,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.3"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.4.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -114,6 +210,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   string_scanner:
     dependency: transitive
     description:
@@ -142,6 +245,48 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.3.0"
+  url_launcher:
+    dependency: "direct main"
+    description:
+      name: url_launcher
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.7.10"
+  url_launcher_linux:
+    dependency: transitive
+    description:
+      name: url_launcher_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+4"
+  url_launcher_macos:
+    dependency: transitive
+    description:
+      name: url_launcher_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+9"
+  url_launcher_platform_interface:
+    dependency: transitive
+    description:
+      name: url_launcher_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.9"
+  url_launcher_web:
+    dependency: transitive
+    description:
+      name: url_launcher_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.5+3"
+  url_launcher_windows:
+    dependency: transitive
+    description:
+      name: url_launcher_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.0.1+3"
   vector_math:
     dependency: transitive
     description:
@@ -151,3 +296,4 @@ packages:
     version: "2.1.0"
 sdks:
   dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.22.0"

--- a/seweco/pubspec.yaml
+++ b/seweco/pubspec.yaml
@@ -28,6 +28,10 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
+  url_launcher: ^5.7.5
+  flutter_linkify: ^5.0.2
+  google_maps_flutter: ^0.5.28
+  google_maps_flutter_web: ^0.1.0
 
 dev_dependencies:
   flutter_test:

--- a/seweco/web/index.html
+++ b/seweco/web/index.html
@@ -11,6 +11,7 @@
     For more details:
     * https://developer.mozilla.org/en-US/docs/Web/HTML/Element/base
   -->
+  <!-- <script src="https://maps.googleapis.com/maps/api/js?key=<API-KEY>"></script> -->
   <base href="/">
 
   <meta charset="UTF-8">


### PR DESCRIPTION
- First pass at UI pages for repair and recycle using text links

Contributes to: https://github.com/bfm404/callforcode-seweco/issues/16
Contributes to: https://github.com/bfm404/callforcode-seweco/issues/18

Signed-off-by: Zoe Gathercole <zoe.gathercole@ibm.com>

Home page: 
![image](https://user-images.githubusercontent.com/62894097/122807965-215b8100-d2c4-11eb-8be4-2829568124a4.png)

Repair page:
![image](https://user-images.githubusercontent.com/62894097/122807974-26b8cb80-d2c4-11eb-90f5-2359faa89827.png)
![image](https://user-images.githubusercontent.com/62894097/122807985-29b3bc00-d2c4-11eb-94f4-453a455afe12.png)
![image](https://user-images.githubusercontent.com/62894097/122808001-2ddfd980-d2c4-11eb-86d1-8384433a3403.png)

Using plain text links for now. Tried to add a Google Maps plugin but you need to set up billing options to get an API key. Would be nice to see a map with pins on for locations rather than hyperlinks (can mention this in our roadmap)

Recycle page:
![image](https://user-images.githubusercontent.com/62894097/122808106-4ea82f00-d2c4-11eb-9747-6034471e0ac7.png)

Resell page:
![image](https://user-images.githubusercontent.com/62894097/122966892-c6885f00-d381-11eb-84ba-577ed2221e80.png)
